### PR TITLE
Upgrade E2E test automation dependencies for iOS 11 and Android 8.0

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -23,12 +23,13 @@ if [ "$MOS" == "OSX" ]; then
     fi
     BREW="/usr/local/bin/brew"
     # ideviceinstaller only works for ios 9. for ios 10, carthage is installed below
-    $BREW upgrade ideviceinstaller &> /dev/null || $BREW install ideviceinstaller
+    $BREW uninstall ideviceinstaller &> /dev/null; $BREW install ideviceinstaller
+    # install ios-deploy using brew, not npm
+    $BREW uninstall ios-deploy &> /dev/null; $BREW install --HEAD ios-deploy
     # install from HEAD to get important updates
-    $BREW upgrade libimobiledevice --HEAD &> /dev/null || $BREW install --HEAD libimobiledevice
+    $BREW uninstall libimobiledevice --HEAD &> /dev/null; $BREW install --HEAD libimobiledevice
     # install carthage
-    $BREW upgrade carthage &> /dev/null || $BREW install carthage
-    $BREW link carthage
+    $BREW uninstall carthage &> /dev/null; $BREW install carthage
 
 # put our own cafile in place
 sudo cp $VENV/lib/python2.7/site-packages/certifi/cacert.pem $($VENV/bin/python -c 'import ssl;print ssl.get_default_verify_paths().openssl_cafile')

--- a/pkgs/zz-test-automation.sh
+++ b/pkgs/zz-test-automation.sh
@@ -1,20 +1,21 @@
 # test automation tooling
 if [ "$MOS" == "OSX" ]; then
-getpkg http://chromedriver.storage.googleapis.com/2.28/chromedriver_mac64.zip
-unzip chromedriver_mac64.zip
-mv chromedriver $VENV/bin/
+    getpkg http://chromedriver.storage.googleapis.com/2.30/chromedriver_mac64.zip
+    unzip chromedriver_mac64.zip
+    mv chromedriver $VENV/bin/
 else
-getpkg http://chromedriver.storage.googleapis.com/2.28/chromedriver_linux64.zip
-unzip chromedriver_linux64.zip
-mv chromedriver $VENV/bin/
+    getpkg http://chromedriver.storage.googleapis.com/2.30/chromedriver_linux64.zip
+    unzip chromedriver_linux64.zip
+    mv chromedriver $VENV/bin/
 fi
 
 # appium requirements
-$VENV/bin/npm install -g appium  # this does not install cleanly on arch...
+$VENV/bin/npm uninstall -g appium
+$VENV/bin/npm install -g appium@1.7.1  # this does not install cleanly on arch...
 if [ "$MOS" == "OSX" ]; then
-$VENV/bin/npm install -g authorize-ios
-$VENV/bin/npm install -g ios-deploy
-$VENV/bin/gem install xcpretty
+    $VENV/bin/npm uninstall -g authorize-ios
+    $VENV/bin/npm install -g authorize-ios@1.0.5
+    $VENV/bin/gem install xcpretty
 fi
 
 # pip install packages for automation support
@@ -28,6 +29,6 @@ $VENV/bin/pip install pytest-rerunfailures
 
 # sym-link iproxy since it's the incorrect version
 if [ "$MOS" == "OSX" ]; then
-sudo mv /sw/bin/iproxy /sw/bin/iproxy_old
-sudo ln -s /ave/bin/iproxy /sw/bin/iproxy
+    sudo mv /sw/bin/iproxy /sw/bin/iproxy_old
+    sudo ln -s /ave/bin/iproxy /sw/bin/iproxy
 fi


### PR DESCRIPTION
Make installation of dependencies more stable by uninstalling package before installing, as opposed to upgrading and then installing on failure.