### PR TITLE
Do not exit on error when attempting to install homebrew dependencies

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -23,13 +23,17 @@ if [ "$MOS" == "OSX" ]; then
     fi
     BREW="/usr/local/bin/brew"
     # ideviceinstaller only works for ios 9. for ios 10, carthage is installed below
-    $BREW uninstall ideviceinstaller &> /dev/null; $BREW install ideviceinstaller
+    $BREW uninstall --force ideviceinstaller &> /dev/null || true
+    $BREW install ideviceinstaller
     # install ios-deploy using brew, not npm
-    $BREW uninstall ios-deploy &> /dev/null; $BREW install --HEAD ios-deploy
+    $BREW uninstall --force ios-deploy &> /dev/null || true
+    $BREW install ios-deploy
     # install from HEAD to get important updates
-    $BREW uninstall libimobiledevice --HEAD &> /dev/null; $BREW install --HEAD libimobiledevice
+    $BREW uninstall --force libimobiledevice &> /dev/null || true
+    $BREW install libimobiledevice
     # install carthage
-    $BREW uninstall carthage &> /dev/null; $BREW install carthage
+    $BREW uninstall --force carthage &> /dev/null || true
+    $BREW install carthage
 
 # put our own cafile in place
 sudo cp $VENV/lib/python2.7/site-packages/certifi/cacert.pem $($VENV/bin/python -c 'import ssl;print ssl.get_default_verify_paths().openssl_cafile')


### PR DESCRIPTION
We expect the uninstall to potentially fail, so ignore errors during this section.