### PR TITLE
RET-2186 Add autopush support for dashboard-api/cross-platform

### DIFF
--- a/pkgs/available/python.sh
+++ b/pkgs/available/python.sh
@@ -35,8 +35,8 @@ $PIP install bcrypt
 $PIP install beanstalkc
 $PIP install BeautifulSoup
 $PIP install bleach
-$PIP install boto
-$PIP install boto3
+$PIP install boto==2.38.0
+$PIP install boto3==1.5.27
 $PIP install bumpversion
 $PIP install certifi
 $PIP install coverage
@@ -44,8 +44,9 @@ $PIP install cython
 $PIP install decorator
 $PIP install dill
 $PIP install dnspython
+$PIP install docker==3.0.1
 $PIP install docutils
-$PIP install fabric
+$PIP install fabric==1.10.1
 $PIP install flask
 $PIP install flask-assets
 $PIP install Flask-Mako
@@ -87,7 +88,7 @@ $PIP install PyPDF2
 $PIP install pytz
 $PIP install raven
 $PIP install redis
-$PIP install requests
+$PIP install requests[security]==2.7.0  # [security] adds additional packages
 $PIP install salt
 $PIP install saws
 # scipy defines these - can't override them


### PR DESCRIPTION
autopush required some additional pip packages.  In this change, only the following was installed/upgraded in ave:
boto==2.38.0
boto3==1.5.27
docker==3.0.1
fabric==1.10.1
requests[security]==2.7.0